### PR TITLE
Content handler

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -15,7 +15,7 @@ const val CUSTOM_CONCEPT_CARD_TAG = "oppia-noninteractive-skillreview"
 class ConceptCardTagHandler(
   private val listener: ConceptCardLinkClickListener,
   private val consoleLogger: ConsoleLogger
-) : CustomHtmlContentHandler.CustomTagHandler {
+) : CustomHtmlContentHandler.CustomTagHandler, CustomHtmlContentHandler.ContentDescriptionProvider {
   override fun handleTag(
     attributes: Attributes,
     openIndex: Int,
@@ -47,5 +47,13 @@ class ConceptCardTagHandler(
      * specified skill ID.
      */
     fun onConceptCardLinkClicked(view: View, skillId: String)
+  }
+
+  override fun getContentDescription(attributes: Attributes): String? {
+    val skillId = attributes.getJsonStringValue("skill_id-with-value")
+    val text = attributes.getJsonStringValue("text-with-value")
+    return if (skillId != null && text != null) {
+      "$text concept card"
+    } else null
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -53,7 +53,7 @@ class ConceptCardTagHandler(
     val skillId = attributes.getJsonStringValue("skill_id-with-value")
     val text = attributes.getJsonStringValue("text-with-value")
     return if (skillId != null && text != null) {
-      "$text concept card"
+      "$text concept card $skillId"
     } else null
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -20,13 +20,11 @@ import org.xml.sax.XMLReader
  */
 class CustomHtmlContentHandler private constructor(
   private val customTagHandlers: Map<String, CustomTagHandler>,
-  private val imageRetriever: ImageRetriever?,
-  private val onContentDescriptionGenerated: ((String) -> Unit)? = null
+  private val imageRetriever: ImageRetriever?
 ) : ContentHandler, Html.TagHandler {
   private var originalContentHandler: ContentHandler? = null
   private var currentTrackedTag: TrackedTag? = null
   private val currentTrackedCustomTags = ArrayDeque<TrackedCustomTag>()
-  private val contentDescriptionBuilder = StringBuilder()
 
   override fun endElement(uri: String?, localName: String?, qName: String?) {
     originalContentHandler?.endElement(uri, localName, qName)
@@ -52,7 +50,6 @@ class CustomHtmlContentHandler private constructor(
   override fun endDocument() {
     originalContentHandler?.endDocument()
     originalContentHandler = null // There's nothing left to read.
-    onContentDescriptionGenerated?.invoke(contentDescriptionBuilder.toString().trim())
   }
 
   override fun startElement(uri: String?, localName: String?, qName: String?, atts: Attributes?) {
@@ -98,8 +95,6 @@ class CustomHtmlContentHandler private constructor(
           check(localCurrentTrackedTag.tag == tag) {
             "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
           }
-          val description = customTagHandlers[tag]?.extractContentDescription(localCurrentTrackedTag.attributes)
-          description?.let { contentDescriptionBuilder.append(it).append(" ") }
           currentTrackedCustomTags += TrackedCustomTag(
             localCurrentTrackedTag.tag, localCurrentTrackedTag.attributes, output.length
           )
@@ -149,22 +144,6 @@ class CustomHtmlContentHandler private constructor(
     ) {
     }
 
-    fun extractContentDescription(attributes: Attributes): String? {
-      val attributeValues = mutableListOf<String>()
-
-      for (i in 0 until attributes.length) {
-        val value = attributes.getValue(i)
-        if (value != null) {
-          attributeValues.add(value)
-        }
-      }
-
-      return if (attributeValues.isNotEmpty()) {
-        attributeValues.joinToString(" ")
-      } else {
-        null
-      }
-    }
     /**
      * Called when the opening of a custom tag is encountered. This does not support processing
      * attributes of the tag--[handleTag] should be used, instead.

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -195,7 +195,7 @@ class CustomHtmlContentHandler private constructor(
     fun handleClosingTag(output: Editable, indentation: Int, tag: String) {}
   }
 
-  /** Handler Interface for tag handlers that provide content descriptions */
+  /** Handler Interface for tag handlers that provide content descriptions. */
   interface ContentDescriptionProvider {
     /**
      * Returns a content description string for this tag based on its attributes,

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -11,7 +11,7 @@ import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
 import org.xml.sax.Locator
 import org.xml.sax.XMLReader
-
+// https://chatgpt.com/c/6761e49f-6824-8003-b645-7913e8c73bbc
 /**
  * A custom [ContentHandler] and [Html.TagHandler] for processing custom HTML tags. This class must
  * be used if a custom tag attribute must be parsed.

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -194,6 +194,8 @@ class CustomHtmlContentHandler private constructor(
      */
     fun handleClosingTag(output: Editable, indentation: Int, tag: String) {}
   }
+
+  /** Handler Interface for tag handlers that provide content descriptions */
   interface ContentDescriptionProvider {
     /**
      * Returns a content description string for this tag based on its attributes,
@@ -201,6 +203,7 @@ class CustomHtmlContentHandler private constructor(
      */
     fun getContentDescription(attributes: Attributes): String?
   }
+
   /**
    * Retriever of images for custom tag handlers. The built-in Android analog for this class is
    * Html's ImageGetter.

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ImageTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ImageTagHandler.kt
@@ -22,7 +22,7 @@ private const val CUSTOM_IMG_CAPTION_ATTRIBUTE = "caption-with-value"
  */
 class ImageTagHandler(
   private val consoleLogger: ConsoleLogger
-) : CustomHtmlContentHandler.CustomTagHandler {
+) : CustomHtmlContentHandler.CustomTagHandler, CustomHtmlContentHandler.ContentDescriptionProvider {
   override fun handleTag(
     attributes: Attributes,
     openIndex: Int,
@@ -100,5 +100,12 @@ class ImageTagHandler(
       "ImageTagHandler",
       "Failed to parse $CUSTOM_IMG_CAPTION_ATTRIBUTE"
     )
+  }
+
+  override fun getContentDescription(attributes: Attributes): String? {
+    val altValue = attributes.getJsonStringValue("alt-with-value")
+    return if (altValue != null) {
+      "Image illustrating $altValue"
+    } else null
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -29,7 +29,7 @@ class MathTagHandler(
   private val lineHeight: Float,
   private val cacheLatexRendering: Boolean,
   private val application: Application
-) : CustomHtmlContentHandler.CustomTagHandler {
+) : CustomHtmlContentHandler.CustomTagHandler, CustomHtmlContentHandler.ContentDescriptionProvider {
   override fun handleTag(
     attributes: Attributes,
     openIndex: Int,
@@ -137,5 +137,12 @@ class MathTagHandler(
         }
       }
     }
+  }
+
+  override fun getContentDescription(attributes: Attributes): String? {
+    val mathVal = attributes.getJsonObjectValue(CUSTOM_MATH_MATH_CONTENT_ATTRIBUTE)
+    return if (mathVal != null) {
+      "Math content $mathVal"
+    } else null
   }
 }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         imageRetriever = mockImageRetriever,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(contentDescription).isEqualTo("refresher lesson concept card")
+    assertThat(contentDescription).isEqualTo("refresher lesson concept card skill_id_1")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -116,6 +116,16 @@ class ConceptCardTagHandlerTest {
     val clickableSpans = parsedHtml.getSpansFromWholeString(ClickableSpan::class)
     assertThat(clickableSpans).hasLength(1)
   }
+  @Test
+  fun testParseHtml_contentDescription() {
+    val parsedHtml =
+      CustomHtmlContentHandler.getContentDescription(
+        html = CONCEPT_CARD_LINK_MARKUP_1,
+        imageRetriever = mockImageRetriever,
+        customTagHandlers = tagHandlersWithConceptCardSupport
+      )
+      assertThat(parsedHtml).isEqualTo("refresher lesson concept card")
+  }
 
   @Test
   fun testParseHtml_withConceptCardMarkup_addsLinkText() {

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -118,13 +118,13 @@ class ConceptCardTagHandlerTest {
   }
   @Test
   fun testParseHtml_contentDescription() {
-    val parsedHtml =
+    val contentDescription =
       CustomHtmlContentHandler.getContentDescription(
         html = CONCEPT_CARD_LINK_MARKUP_1,
         imageRetriever = mockImageRetriever,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(parsedHtml).isEqualTo("refresher lesson concept card")
+    assertThat(contentDescription).isEqualTo("refresher lesson concept card")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         imageRetriever = mockImageRetriever,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-      assertThat(parsedHtml).isEqualTo("refresher lesson concept card")
+    assertThat(parsedHtml).isEqualTo("refresher lesson concept card")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/CustomHtmlContentHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/CustomHtmlContentHandlerTest.kt
@@ -315,6 +315,22 @@ class CustomHtmlContentHandlerTest {
     assertThat(contentDescription).isEqualTo("Outer Tag before Inner Tag nested after")
   }
 
+  @Test
+  fun testGetContentDescription_withMultipleTags_preservesOrder() {
+    val firstHandler = FakeContentDescriptionTagHandler("First ")
+    val secondHandler = FakeContentDescriptionTagHandler("Second ")
+    val contentDescription = CustomHtmlContentHandler.getContentDescription(
+      html = "Start <first-tag>one</first-tag> middle <second-tag>two</second-tag> end",
+      imageRetriever = mockImageRetriever,
+      customTagHandlers = mapOf(
+        "first-tag" to firstHandler,
+        "second-tag" to secondHandler
+      )
+    )
+
+    assertThat(contentDescription).isEqualTo("Start First one middle Second two end")
+  }
+
   private fun <T : Any> Spannable.getSpansFromWholeString(spanClass: KClass<T>): Array<T> =
     getSpans(/* start= */ 0, /* end= */ length, spanClass.javaObjectType)
 

--- a/utility/src/test/java/org/oppia/android/util/parser/html/CustomHtmlContentHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/CustomHtmlContentHandlerTest.kt
@@ -316,7 +316,7 @@ class CustomHtmlContentHandlerTest {
     return DisplayLocaleImpl(context, formattingLocale, machineLocale, formatterFactory)
   }
 
-  private class FakeTagHandler : CustomHtmlContentHandler.CustomTagHandler {
+  private class FakeTagHandler : CustomTagHandler {
     var handleTagCalled = false
     var handleTagCallIndex = -1
     var handleOpeningTagCalled = false
@@ -358,7 +358,7 @@ class CustomHtmlContentHandlerTest {
 
   private class ReplacingTagHandler(
     private val attributeTextToReplaceWith: String
-  ) : CustomHtmlContentHandler.CustomTagHandler {
+  ) : CustomTagHandler {
     override fun handleTag(
       attributes: Attributes,
       openIndex: Int,

--- a/utility/src/test/java/org/oppia/android/util/parser/html/CustomHtmlContentHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/CustomHtmlContentHandlerTest.kt
@@ -298,6 +298,23 @@ class CustomHtmlContentHandlerTest {
     assertThat(jsonObject?.getString("key")).isEqualTo("value with \\frac{1}{2}")
   }
 
+  @Test
+  fun testGetContentDescription_withNestedTags_handlesNestingCorrectly() {
+    val outerHandler = FakeContentDescriptionTagHandler("Outer Tag ")
+    val innerHandler = FakeContentDescriptionTagHandler("Inner Tag ")
+
+    val contentDescription = CustomHtmlContentHandler.getContentDescription(
+      html = "<outer-tag>before <inner-tag>nested</inner-tag> after</outer-tag>",
+      imageRetriever = mockImageRetriever,
+      customTagHandlers = mapOf(
+        "outer-tag" to outerHandler,
+        "inner-tag" to innerHandler
+      )
+    )
+
+    assertThat(contentDescription).isEqualTo("Outer Tag before Inner Tag nested after")
+  }
+
   private fun <T : Any> Spannable.getSpansFromWholeString(spanClass: KClass<T>): Array<T> =
     getSpans(/* start= */ 0, /* end= */ length, spanClass.javaObjectType)
 
@@ -315,7 +332,22 @@ class CustomHtmlContentHandlerTest {
     val formattingLocale = androidLocaleFactory.createOneOffAndroidLocale(context)
     return DisplayLocaleImpl(context, formattingLocale, machineLocale, formatterFactory)
   }
+  private class FakeContentDescriptionTagHandler(
+    private val contentDesc: String
+  ) : CustomTagHandler, CustomHtmlContentHandler.ContentDescriptionProvider {
+    override fun handleTag(
+      attributes: Attributes,
+      openIndex: Int,
+      closeIndex: Int,
+      output: Editable,
+      imageRetriever: CustomHtmlContentHandler.ImageRetriever?
+    ) {
+    }
 
+    override fun getContentDescription(attributes: Attributes): String {
+      return contentDesc
+    }
+  }
   private class FakeTagHandler : CustomTagHandler {
     var handleTagCalled = false
     var handleTagCallIndex = -1

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ImageTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ImageTagHandlerTest.kt
@@ -325,6 +325,17 @@ class ImageTagHandlerTest {
       .inOrder()
   }
 
+  @Test
+  fun testParseHtml_contentDescription() {
+    val contentDescription =
+      CustomHtmlContentHandler.getContentDescription(
+        html = IMAGE_TAG_MARKUP_1,
+        imageRetriever = mockImageRetriever,
+        customTagHandlers = tagHandlersWithImageTagSupport
+      )
+    assertThat(contentDescription).isEqualTo("Image illustrating alt text 1")
+  }
+
   private fun <T : Any> Spannable.getSpansFromWholeString(spanClass: KClass<T>): Array<T> =
     getSpans(/* start= */ 0, /* end= */ length, spanClass.javaObjectType)
 

--- a/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
@@ -302,6 +302,21 @@ class MathTagHandlerTest {
   }
 
   @Test
+  fun testParseHtml_contentDescription() {
+    val contentDescription =
+      CustomHtmlContentHandler.getContentDescription(
+        html = MATH_MARKUP_1,
+        imageRetriever = mockImageRetriever,
+        customTagHandlers = tagHandlersWithCachedMathSupport
+      )
+
+    assertThat(contentDescription).isEqualTo(
+      "Math content" +
+        " {\"raw_latex\":\"\\\\frac{2}{5}\",\"svg_filename\":\"math_image1.svg\"}"
+    )
+  }
+
+  @Test
   fun testParseHtml_withMathMarkup_loadsInlineImageForFilename() {
     CustomHtmlContentHandler.fromHtml(
       html = MATH_MARKUP_1,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
