### PR TITLE
Kdoc regex

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/audio/LanguageInterface.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/LanguageInterface.kt
@@ -11,7 +11,7 @@ interface LanguageInterface {
   /**
    * Returns whether the user is actively seeking a new audio position, that is, dragging the
    * knob to a new position in the audio track.
-   * */
+   */
   fun getUserIsSeeking(): Boolean
 
   /** Returns the position of the knob on the audio track. */

--- a/app/src/main/java/org/oppia/android/app/shim/IntentFactoryShim.kt
+++ b/app/src/main/java/org/oppia/android/app/shim/IntentFactoryShim.kt
@@ -16,7 +16,7 @@ interface IntentFactoryShim {
   /**
    * Creates a [TopicActivity] intent for [PromotedStoryViewModel] and passes necessary string
    * data.
-   * */
+   */
   fun createTopicPlayStoryActivityIntent(
     context: Context,
     internalProfileId: Int,
@@ -27,7 +27,7 @@ interface IntentFactoryShim {
 
   /**
    * Creates a [TopicActivity] intent which opens info-tab.
-   * */
+   */
   fun createTopicActivityIntent(
     context: Context,
     internalProfileId: Int,

--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentScroller.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentScroller.kt
@@ -4,6 +4,6 @@ interface StoryFragmentScroller {
   /**
    * Scrolls smoothly (with animation) to the specified vertical pixel position in
    * [StoryFragment].
-   * */
+   */
   fun smoothScrollToPosition(position: Int)
 }

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandler.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandler.kt
@@ -35,7 +35,7 @@ interface HintHandler {
    * @param trackedWrongAnswerCount the count of wrong answers saved in the checkpoint
    * @param helpIndex the cached state of hints/solution from the checkpoint
    * @param state the restored pending state
-   * */
+   */
   suspend fun resumeHintsForSavedState(
     trackedWrongAnswerCount: Int,
     helpIndex: HelpIndex,

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/exceptions/ExceptionsController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/exceptions/ExceptionsController.kt
@@ -113,7 +113,7 @@ class ExceptionsController @Inject constructor(
    * At first, it checks if the size of the store isn't exceeding [exceptionLogStorageCacheSize].
    * If the limit is exceeded then the least recent exception is removed from the [exceptionLogStore].
    * After this, the [exceptionLog] is added to the store.
-   * */
+   */
   private fun cacheExceptionLog(exceptionLog: ExceptionLog) {
     exceptionLogStore.storeDataAsync(true) { oppiaExceptionLogs ->
       val storeSize = oppiaExceptionLogs.exceptionLogList.size

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -503,8 +503,8 @@ file_content_checks {
 }
 file_content_checks {
   file_path_regex: ".+?\\.kt$"
-  prohibited_content_regex: "\\*\\*/"
-  failure_message: "Badly formatted KDoc or block comment. KDocs and block comments should only end with \"*/\"."
+  prohibited_content_regex: "\\*(\\s*\\*|\\*)/"
+  failure_message: "Badly formatted KDoc or block comment. KDocs and block comments should only end with \"*/\". Multiple asterisks or whitespace between asterisks are not allowed."
   exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
 }
 file_content_checks {

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -2582,7 +2582,7 @@ class RegexPatternValidationCheckTest {
       /**
        * Correct KDoc comment.
        */
-    """.trimIndent()
+      """.trimIndent()
     tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
     val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
     tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
@@ -2604,7 +2604,7 @@ class RegexPatternValidationCheckTest {
       $stringFilePath:12: $badKdocOrBlockCommentShouldEndWithCorrectEnding
       $stringFilePath:2: $badSingleLineKdocShouldEndWithPunctuation
       $wikiReferenceNote
-      """.trimIndent()
+        """.trimIndent()
       )
   }
 

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -2621,7 +2621,7 @@ class RegexPatternValidationCheckTest {
        /**
          * Correct KDoc comment.
          */
-    """.trimIndent()
+      """.trimIndent()
     tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
     val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
     tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
@@ -2635,7 +2635,7 @@ class RegexPatternValidationCheckTest {
       $stringFilePath:3: $badKdocOrBlockCommentShouldEndWithCorrectEnding
       $stringFilePath:6: $badKdocOrBlockCommentShouldEndWithCorrectEnding
       $wikiReferenceNote
-      """.trimIndent()
+        """.trimIndent()
       )
   }
 

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -206,7 +206,8 @@ class RegexPatternValidationCheckTest {
     "Badly formatted KDoc. Single-line KDocs should always end with exactly one space before the" +
       " final \"*/\"."
   private val badKdocOrBlockCommentShouldEndWithCorrectEnding =
-    "Badly formatted KDoc or block comment. KDocs and block comments should only end with \"*/\"."
+    "Badly formatted KDoc or block comment. KDocs and block comments should only" +
+      " end with \"*/\". Multiple asterisks or whitespace between asterisks are not allowed."
   private val badKdocParamsAndPropertiesShouldHaveNameFollowing =
     "Badly formatted KDoc param or property at-clause: the name of the parameter or property" +
       " should immediately follow the at-clause without any additional linking with brackets."
@@ -2566,22 +2567,22 @@ class RegexPatternValidationCheckTest {
   fun testFileContent_multipleCommentTypesWithExtraCharactersBeforeEnd_fileContentIsNotCorrect() {
     val prohibitedContent =
       """
-      /** Content here.*/
-      /** Content here. **/
-      /** Correct KDoc. */
+        /** Content here.*/
+        /** Content here. **/
+        /** Correct KDoc. */
 
-      /*
-       * Incorrect block comment.
-       **/
-      /*
-       * Correct block comment.
-       */
-      /**
-       * Incorrect KDoc comment.
-       * */
-      /**
-       * Correct KDoc comment.
-       */
+        /*
+         * Incorrect block comment.
+         **/
+        /*
+         * Correct block comment.
+         */
+        /**
+         * Incorrect KDoc comment.
+         **/
+        /**
+         * Correct KDoc comment.
+         */
       """.trimIndent()
     tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
     val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
@@ -2596,15 +2597,45 @@ class RegexPatternValidationCheckTest {
     assertThat(outContent.toString().trim())
       .isEqualTo(
         """
-      $stringFilePath:1: $badSingleLineKdocShouldHaveSpacesBeforeEnding
-      $stringFilePath:2: $badSingleLineKdocShouldHaveSpacesBeforeEnding
-      $stringFilePath:2: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-      $stringFilePath:7: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-      $stringFilePath:13: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-      $stringFilePath:12: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-      $stringFilePath:2: $badSingleLineKdocShouldEndWithPunctuation
-      $wikiReferenceNote
+        $stringFilePath:1: $badSingleLineKdocShouldHaveSpacesBeforeEnding
+        $stringFilePath:2: $badSingleLineKdocShouldHaveSpacesBeforeEnding
+        $stringFilePath:2: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+        $stringFilePath:7: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+        $stringFilePath:13: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+        $stringFilePath:2: $badSingleLineKdocShouldEndWithPunctuation
+        $wikiReferenceNote
         """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_kdocWithInvalidEndingSequences_failsValidation() {
+    val prohibitedContent =
+      """
+      /**
+       * Incorrect KDoc comment.
+       * */
+       /**
+       * Incorrect KDoc comment.
+       **/
+       /**
+         * Correct KDoc comment.
+         */
+    """.trimIndent()
+    tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
+    val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows<Exception>() { runScript() }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+      $stringFilePath:3: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+      $stringFilePath:6: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+      $wikiReferenceNote
+      """.trimIndent()
       )
   }
 

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -2566,23 +2566,23 @@ class RegexPatternValidationCheckTest {
   fun testFileContent_multipleCommentTypesWithExtraCharactersBeforeEnd_fileContentIsNotCorrect() {
     val prohibitedContent =
       """
-        /** Content here.*/
-        /** Content here. **/
-        /** Correct KDoc. */
+      /** Content here.*/
+      /** Content here. **/
+      /** Correct KDoc. */
 
-        /*
-         * Incorrect block comment.
-         **/
-        /*
-         * Correct block comment.
-         */
-        /**
-         * Incorrect KDoc comment.
-         **/
-        /**
-         * Correct KDoc comment.
-         */
-      """.trimIndent()
+      /*
+       * Incorrect block comment.
+       **/
+      /*
+       * Correct block comment.
+       */
+      /**
+       * Incorrect KDoc comment.
+       * */
+      /**
+       * Correct KDoc comment.
+       */
+    """.trimIndent()
     tempFolder.newFolder("testfiles", "app", "src", "main", "java", "org", "oppia", "android")
     val stringFilePath = "app/src/main/java/org/oppia/android/TestPresenter.kt"
     tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
@@ -2596,14 +2596,15 @@ class RegexPatternValidationCheckTest {
     assertThat(outContent.toString().trim())
       .isEqualTo(
         """
-        $stringFilePath:1: $badSingleLineKdocShouldHaveSpacesBeforeEnding
-        $stringFilePath:2: $badSingleLineKdocShouldHaveSpacesBeforeEnding
-        $stringFilePath:2: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-        $stringFilePath:7: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-        $stringFilePath:13: $badKdocOrBlockCommentShouldEndWithCorrectEnding
-        $stringFilePath:2: $badSingleLineKdocShouldEndWithPunctuation
-        $wikiReferenceNote
-        """.trimIndent()
+      $stringFilePath:1: $badSingleLineKdocShouldHaveSpacesBeforeEnding
+      $stringFilePath:2: $badSingleLineKdocShouldHaveSpacesBeforeEnding
+      $stringFilePath:2: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+      $stringFilePath:7: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+      $stringFilePath:13: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+      $stringFilePath:12: $badKdocOrBlockCommentShouldEndWithCorrectEnding
+      $stringFilePath:2: $badSingleLineKdocShouldEndWithPunctuation
+      $wikiReferenceNote
+      """.trimIndent()
       )
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
