### PR TITLE
Image region selection interaction

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/ImageRegionSelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/ImageRegionSelectionInteractionView.kt
@@ -64,8 +64,8 @@ class ImageRegionSelectionInteractionView @JvmOverloads constructor(
     maybeInitializeClickableAreas()
   }
 
-  fun setUserAnswerState(userAnswerrState: UserAnswerState) {
-    this.userAnswerState = userAnswerrState
+  fun setUserAnswerState(userAnswerState: UserAnswerState) {
+    this.userAnswerState = userAnswerState
   }
 
   fun setEntityId(entityId: String) {

--- a/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
@@ -112,8 +112,13 @@ class ClickableAreasImage(
       newView.isFocusable = true
       newView.isFocusableInTouchMode = true
       newView.tag = clickableArea.label
+
+      val isInitiallySelected = clickableArea.label.equals(imageLabel)
+      updateRegionContentDescription(newView, clickableArea, isInitiallySelected)
+
       newView.initializeToggleRegionTouchListener(clickableArea)
-      if (clickableArea.label.equals(imageLabel)) {
+
+      if (isInitiallySelected) {
         showOrHideRegion(newView = newView, clickableArea = clickableArea)
       }
       if (isAccessibilityEnabled) {
@@ -123,7 +128,7 @@ class ClickableAreasImage(
           showOrHideRegion(newView, clickableArea)
         }
       }
-      newView.contentDescription = clickableArea.contentDescription
+
       parentView.addView(newView)
     }
 
@@ -142,12 +147,33 @@ class ClickableAreasImage(
     }
   }
 
+  private fun generateContentDescription(
+    clickableArea: LabeledRegion,
+    isSelected: Boolean
+  ): String {
+    val regionType = clickableArea.region.regionType.name.lowercase()
+      .replaceFirstChar { it.uppercaseChar() }
+    val selectionState = if (isSelected) "Unselect" else "Select"
+
+    return "$selectionState $regionType region: ${clickableArea.label}."
+  }
+
+  private fun updateRegionContentDescription(
+    view: View,
+    clickableArea: LabeledRegion,
+    isSelected: Boolean
+  ) {
+    view.contentDescription = generateContentDescription(clickableArea, isSelected)
+  }
+
   private fun showOrHideRegion(newView: View, clickableArea: LabeledRegion) {
+    val isBecomingSelected = newView.background == null
     resetRegionSelectionViews()
+
     listener.onClickableAreaTouched(
       NamedRegionClickedEvent(
         clickableArea.label,
-        clickableArea.contentDescription
+        generateContentDescription(clickableArea, isBecomingSelected)
       )
     )
     newView.setBackgroundResource(R.drawable.selected_region_background)

--- a/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
@@ -196,11 +196,10 @@ class ClickableAreasImage(
     clickableArea: LabeledRegion,
     isSelected: Boolean
   ): String {
-    val regionType = clickableArea.region.regionType.name
     if (isSelected) {
-      return "This is a ${regionType.lowercase()} region ${clickableArea.label}."
+      return "This is a ${clickableArea.label} image."
     }
-    return "Select ${regionType.lowercase()} region ${clickableArea.label}."
+    return "Select ${clickableArea.label} image."
   }
 
   private fun updateRegionContentDescription(

--- a/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
@@ -60,6 +60,16 @@ class ClickableAreasImage(
       // Remove any previously selected region excluding 0th index(image view)
       if (index > 0) {
         childView.setBackgroundResource(0)
+        if (childView.tag != null) {
+          val regionLabel = childView.tag as String
+          clickableAreas.find { it.label == regionLabel }?.let { clickableArea ->
+            updateRegionContentDescription(
+              childView,
+              clickableArea,
+              regionLabel == imageLabel
+            )
+          }
+        }
       }
     }
   }
@@ -147,35 +157,19 @@ class ClickableAreasImage(
     }
   }
 
-  private fun generateContentDescription(
-    clickableArea: LabeledRegion,
-    isSelected: Boolean
-  ): String {
-    val regionType = clickableArea.region.regionType.name
-    val selectionState = if (isSelected) "Unselect" else "Select"
-
-    return "$selectionState $regionType region: ${clickableArea.label}."
-  }
-
-  private fun updateRegionContentDescription(
-    view: View,
-    clickableArea: LabeledRegion,
-    isSelected: Boolean
-  ) {
-    view.contentDescription = generateContentDescription(clickableArea, isSelected)
-  }
-
   private fun showOrHideRegion(newView: View, clickableArea: LabeledRegion) {
-    val isBecomingSelected = newView.background == null
-    resetRegionSelectionViews()
+    if (clickableArea.label != imageLabel) {
+      imageLabel = clickableArea.label
+      resetRegionSelectionViews()
+      newView.setBackgroundResource(R.drawable.selected_region_background)
 
-    listener.onClickableAreaTouched(
-      NamedRegionClickedEvent(
-        clickableArea.label,
-        generateContentDescription(clickableArea, isBecomingSelected)
+      listener.onClickableAreaTouched(
+        NamedRegionClickedEvent(
+          clickableArea.label,
+          generateContentDescription(clickableArea, true)
+        )
       )
-    )
-    newView.setBackgroundResource(R.drawable.selected_region_background)
+    }
   }
 
   private fun View.initializeShowRegionTouchListener() {
@@ -196,5 +190,24 @@ class ClickableAreasImage(
       view.performClick()
       return@setOnTouchListener true
     }
+  }
+
+  private fun generateContentDescription(
+    clickableArea: LabeledRegion,
+    isSelected: Boolean
+  ): String {
+    val regionType = clickableArea.region.regionType.name
+    if (isSelected) {
+      return "This is a ${regionType.lowercase()} region ${clickableArea.label}."
+    }
+    return "Select ${regionType.lowercase()} region ${clickableArea.label}."
+  }
+
+  private fun updateRegionContentDescription(
+    view: View,
+    clickableArea: LabeledRegion,
+    isSelected: Boolean
+  ) {
+    view.contentDescription = generateContentDescription(clickableArea, isSelected)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
@@ -151,8 +151,7 @@ class ClickableAreasImage(
     clickableArea: LabeledRegion,
     isSelected: Boolean
   ): String {
-    val regionType = clickableArea.region.regionType.name.lowercase()
-      .replaceFirstChar { it.uppercaseChar() }
+    val regionType = clickableArea.region.regionType.name
     val selectionState = if (isSelected) "Unselect" else "Select"
 
     return "$selectionState $regionType region: ${clickableArea.label}."

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -113,6 +113,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 
 /** Tests for [StateFragment]. */
 @RunWith(AndroidJUnit4::class)
@@ -229,8 +230,12 @@ class ImageRegionSelectionInteractionViewTest {
   @RunOn(TestPlatform.ESPRESSO)
   fun testImageRegionSelectionInteractionView_initialContentDescriptionRegion3_isCorrect() {
     launch(ImageRegionSelectionTestActivity::class.java).use {
-      onView(allOf(withTagValue(`is`("Region 3"))))
-        .check(matches(withContentDescription("Select Rectangle region: Region 3.")))
+      onView(
+        allOf(
+          withTagValue(`is`("Region 3")),
+          withContentDescription("Select Rectangle region: Region 3.")
+        )
+      ).check(matches(isDisplayed()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -227,6 +227,16 @@ class ImageRegionSelectionInteractionViewTest {
   @Test
   // TODO(#1611): Fix ImageRegionSelectionInteractionViewTest
   @RunOn(TestPlatform.ESPRESSO)
+  fun testImageRegionSelectionInteractionView_initialContentDescriptionRegion3_isCorrect() {
+    launch(ImageRegionSelectionTestActivity::class.java).use {
+      onView(allOf(withTagValue(`is`("Region 3"))))
+        .check(matches(withContentDescription("Select rectangle region: Region 3.")))
+    }
+  }
+
+  @Test
+  // TODO(#1611): Fix ImageRegionSelectionInteractionViewTest
+  @RunOn(TestPlatform.ESPRESSO)
   fun testImageRegionSelectionInteractionView_clickOnDefaultRegion_defaultRegionClicked() {
     launch(ImageRegionSelectionTestActivity::class.java).use { scenario ->
       scenario.onActivity { activity ->

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -177,7 +177,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "Unselect rectangle region: Region 3."
+            regionLabel = "Region 3", contentDescription = "Unselect Rectangle region: Region 3."
           )
         )
     }
@@ -218,7 +218,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "Unselect rectangle region: Region 2."
+            regionLabel = "Region 2", contentDescription = "Unselect Rectangle region: Region 2."
           )
         )
     }
@@ -230,7 +230,7 @@ class ImageRegionSelectionInteractionViewTest {
   fun testImageRegionSelectionInteractionView_initialContentDescriptionRegion3_isCorrect() {
     launch(ImageRegionSelectionTestActivity::class.java).use {
       onView(allOf(withTagValue(`is`("Region 3"))))
-        .check(matches(withContentDescription("Select rectangle region: Region 3.")))
+        .check(matches(withContentDescription("Select Rectangle region: Region 3.")))
     }
   }
 
@@ -290,7 +290,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "Unselect rectangle region: Region 2."
+            regionLabel = "Region 2", contentDescription = "Unselect Rectangle region: Region 2."
           )
         )
     }
@@ -318,7 +318,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "Unselect rectangle region: Region 3."
+            regionLabel = "Region 3", contentDescription = "Unselect Rectangle region: Region 3."
           )
         )
     }
@@ -362,7 +362,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "Unselect rectangle region: Region 3."
+            regionLabel = "Region 3", contentDescription = "Unselect Rectangle region: Region 3."
           )
         )
     }
@@ -404,7 +404,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "Unselect rectangle region: Region 2."
+            regionLabel = "Region 2", contentDescription = "Unselect Rectangle region: Region 2."
           )
         )
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -178,7 +178,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "This is a rectangle region Region 3."
+            regionLabel = "Region 3", contentDescription = "This is a Region 3 image."
           )
         )
     }
@@ -219,7 +219,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "This is a rectangle region Region 2."
+            regionLabel = "Region 2", contentDescription = "This is a Region 2 image."
           )
         )
     }
@@ -233,7 +233,7 @@ class ImageRegionSelectionInteractionViewTest {
       onView(
         allOf(
           withTagValue(`is`("Region 3")),
-          withContentDescription("Select rectangle region Region 3.")
+          withContentDescription("Select Region 3 image.")
         )
       ).check(matches(isDisplayed()))
     }
@@ -295,7 +295,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "This is a rectangle region Region 2."
+            regionLabel = "Region 2", contentDescription = "This is a Region 2 image."
           )
         )
     }
@@ -323,7 +323,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "This is a rectangle region Region 3."
+            regionLabel = "Region 3", contentDescription = "This is a Region 3 image."
           )
         )
     }
@@ -367,7 +367,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "This is a rectangle region Region 3."
+            regionLabel = "Region 3", contentDescription = "This is a Region 3 image."
           )
         )
     }
@@ -409,7 +409,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "This is a rectangle region Region 2."
+            regionLabel = "Region 2", contentDescription = "This is a Region 2 image."
           )
         )
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withTagValue
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -113,7 +114,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 
 /** Tests for [StateFragment]. */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -177,7 +177,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "You have selected Region 3"
+            regionLabel = "Region 3", contentDescription = "Unselect rectangle region: Region 3."
           )
         )
     }
@@ -218,7 +218,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "You have selected Region 2"
+            regionLabel = "Region 2", contentDescription = "Unselect rectangle region: Region 2."
           )
         )
     }
@@ -280,7 +280,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "You have selected Region 2"
+            regionLabel = "Region 2", contentDescription = "Unselect rectangle region: Region 2."
           )
         )
     }
@@ -308,7 +308,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "You have selected Region 3"
+            regionLabel = "Region 3", contentDescription = "Unselect rectangle region: Region 3."
           )
         )
     }
@@ -352,7 +352,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "You have selected Region 3"
+            regionLabel = "Region 3", contentDescription = "Unselect rectangle region: Region 3."
           )
         )
     }
@@ -394,7 +394,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "You have selected Region 2"
+            regionLabel = "Region 2", contentDescription = "Unselect rectangle region: Region 2."
           )
         )
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -178,7 +178,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "Unselect Rectangle region: Region 3."
+            regionLabel = "Region 3", contentDescription = "This is a rectangle region Region 3."
           )
         )
     }
@@ -219,7 +219,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "Unselect Rectangle region: Region 2."
+            regionLabel = "Region 2", contentDescription = "This is a rectangle region Region 2."
           )
         )
     }
@@ -233,7 +233,7 @@ class ImageRegionSelectionInteractionViewTest {
       onView(
         allOf(
           withTagValue(`is`("Region 3")),
-          withContentDescription("Select Rectangle region: Region 3.")
+          withContentDescription("Select rectangle region Region 3.")
         )
       ).check(matches(isDisplayed()))
     }
@@ -295,7 +295,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "Unselect Rectangle region: Region 2."
+            regionLabel = "Region 2", contentDescription = "This is a rectangle region Region 2."
           )
         )
     }
@@ -323,7 +323,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "Unselect Rectangle region: Region 3."
+            regionLabel = "Region 3", contentDescription = "This is a rectangle region Region 3."
           )
         )
     }
@@ -367,7 +367,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 3", contentDescription = "Unselect Rectangle region: Region 3."
+            regionLabel = "Region 3", contentDescription = "This is a rectangle region Region 3."
           )
         )
     }
@@ -409,7 +409,7 @@ class ImageRegionSelectionInteractionViewTest {
       assertThat(regionClickedEvent.value)
         .isEqualTo(
           NamedRegionClickedEvent(
-            regionLabel = "Region 2", contentDescription = "Unselect Rectangle region: Region 2."
+            regionLabel = "Region 2", contentDescription = "This is a rectangle region Region 2."
           )
         )
     }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
